### PR TITLE
[CHANGED] Removed physics warp restriction to lossless physics

### DIFF
--- a/BetterTimeWarp/BetterTimeWarp.cs
+++ b/BetterTimeWarp/BetterTimeWarp.cs
@@ -818,7 +818,7 @@ namespace BetterTimeWarp
 
         void FixedUpdate()
         {
-            if (TimeWarp.fetch != null &&  TimeWarp.fetch.Mode == TimeWarp.Modes.HIGH && UseLosslessPhysics && Time.timeScale < 100f)
+            if (TimeWarp.fetch != null && UseLosslessPhysics && Time.timeScale < 100f)
             {
                 if (Time.timeScale == 1f)
                 {


### PR DESCRIPTION
Hey !

While experimenting with this mod and the lossless physics, I found that the lossless physics does not work while in physics warp. I believe this is unintended and that the lossless physic should work while in physics warp.


After a bit of investigation, I found that this issue occur because the mod check `TimeWarp.fetch.Mode == TimeWarp.Modes.HIGH` before changing `fixedDeltaTime` and I think that `TimeWarp.Modes.HIGH` mean "rail warp".

By removing that check from the condition before updating `fixedDeltaTime`, the lossless physic is applied regardless of if we are in physics warp or rail warp.

One potential side effect of that change is that the game smoothly change the `fixedDeltaTime` when changing the game's speed and that smoothing may override the mod for the duration of that smoothing. Once the smoothing is done, the mod scales the physic properly. Aside from that, I found that this change reduce the effect of the "warp kraken", especially when using a rover.

I am very new to KSP modding, please let me know if this PR is a bad idea/not a bug fix.
Cheers !