### PR TITLE
Gate the per-frame warp-name rebuild on windowOpen (kills ~3.9 KB/frame of GC)

### DIFF
--- a/BetterTimeWarp/BetterTimeWarp.cs
+++ b/BetterTimeWarp/BetterTimeWarp.cs
@@ -455,28 +455,38 @@ namespace BetterTimeWarp
 
         void Update()
         {
-            warpNames.Clear();
-            physNames.Clear();
-            warpRates = customWarps.Where(r => !r.Physics).ToArray();
-            physRates = customWarps.Where(r => r.Physics).ToArray();
-
-            foreach (var rates in customWarps)
+            // These per-rate arrays + colour-coded name strings are ONLY consumed by the warp-selection
+            // window (drawn only while windowOpen); customWarps only changes at load (LoadCustomWarpRates
+            // already populates warpRates/physRates there) or via the window's own add/remove handlers
+            // (which run while windowOpen). Rebuilding them EVERY frame - two LINQ ToArray() + per-rate
+            // string concat + a Concat().ToArray() - was ~3.9 KB/frame of pure GC pressure while the
+            // window was closed (i.e. almost always). Gate on windowOpen: closed = zero allocation,
+            // open = identical behaviour (live <color=lime> highlight).
+            if (windowOpen)
             {
-                string sB = "";
-                string sA = "";
-                if (rates == CurrentWarp || rates == CurrentPhysWarp)
+                warpNames.Clear();
+                physNames.Clear();
+                warpRates = customWarps.Where(r => !r.Physics).ToArray();
+                physRates = customWarps.Where(r => r.Physics).ToArray();
+
+                foreach (var rates in customWarps)
                 {
-                    sB = "<color=lime>";
-                    sA = "</color>";
+                    string sB = "";
+                    string sA = "";
+                    if (rates == CurrentWarp || rates == CurrentPhysWarp)
+                    {
+                        sB = "<color=lime>";
+                        sA = "</color>";
+                    }
+
+                    if (rates.Physics)
+                        physNames.Add(sB + rates.Name + sA);
+                    else
+                        warpNames.Add(sB + rates.Name + sA);
                 }
 
-                if (rates.Physics)
-                    physNames.Add(sB + rates.Name + sA);
-                else
-                    warpNames.Add(sB + rates.Name + sA);
+                names = warpNames.Concat(physNames).ToArray();
             }
-
-            names = warpNames.Concat(physNames).ToArray();
 
             //make camera speed not change with time warp
             if (ScaleCameraSpeed && Time.timeScale < 1f)


### PR DESCRIPTION
Update() rebuilt warpRates/physRates (two LINQ Where().ToArray()), the colour-coded
warpNames/physNames strings, and names (Concat().ToArray()) on EVERY frame. These are
only consumed by the warp-selection window, which is drawn only while windowOpen, and
customWarps only changes at load (LoadCustomWarpRates already populates the arrays there)
or via the window's own add/remove handlers (which run while the window is open).

Rebuilding them while the window is closed - i.e. almost always - was ~3.9 KB/frame of
pure garbage, feeding the Boehm GC toward its periodic collection stalls. Gate the whole
block on windowOpen: closed = zero allocation, open = byte-identical behaviour including
the live <color=lime> current-rate highlight.

Found with the Unity profiler (dev-player attach, GC.Alloc column) while hunting
per-frame allocation in a heavily-modded install.
